### PR TITLE
Fix the issue around AssignmentDetails 

### DIFF
--- a/src/main/java/seedu/address/model/assignmentdetails/AssignmentDetails.java
+++ b/src/main/java/seedu/address/model/assignmentdetails/AssignmentDetails.java
@@ -9,8 +9,9 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class AssignmentDetails {
 
-    public static final String MESSAGE_CONSTRAINTS = "Assignment details should be alphanumeric";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final String MESSAGE_CONSTRAINTS = "Assignment details should only contain alphanumeric characters "
+            + "and spaces, and it should not be blank";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
 
     public final String assignmentDetails;
 

--- a/src/test/java/seedu/address/model/assignmentdetails/AssignmentDetailsTest.java
+++ b/src/test/java/seedu/address/model/assignmentdetails/AssignmentDetailsTest.java
@@ -26,11 +26,10 @@ public class AssignmentDetailsTest {
 
         // invalid assignment details
         assertFalse(AssignmentDetails.areValidAssignmentDetails("-!")); // Non-alphanumeric
-        assertFalse(AssignmentDetails.areValidAssignmentDetails("Assignment 1")); // No spaces allowed
 
         // valid assignment details
+        assertTrue(AssignmentDetails.areValidAssignmentDetails("Assignment 1")); // Spaces allowed
         assertTrue(AssignmentDetails.areValidAssignmentDetails("Assignment1"));
-        assertTrue(AssignmentDetails.areValidAssignmentDetails("Lab1"));
-        assertTrue(AssignmentDetails.areValidAssignmentDetails("Tutorial1"));
+        assertTrue(AssignmentDetails.areValidAssignmentDetails("Tutorial 1 Assignment 1")); // Multiple words
     }
 }


### PR DESCRIPTION
AssignmentDetails produces an error when the user inputs more than one word into the assignment detail field in the add command. This PR fixes this problem with a change to the Regex, along with some changes to the tests so that all of the tests pass.