### PR TITLE
Fix plural mistake in error message

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -15,8 +15,8 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_INVALID_MODULE_DISPLAYED_INDEX = "The module index provided is invalid";
-    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
-    public static final String MESSAGE_MODULES_LISTED_OVERVIEW = "%1$d modules listed!";
+    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d person(s) listed!";
+    public static final String MESSAGE_MODULES_LISTED_OVERVIEW = "%1$d module(s) listed!";
 
     /* Error messages for "almost" wrong commands*/
     public static final String MESSAGE_INVALID_ADD_COMMAND = MESSAGE_UNKNOWN_COMMAND


### PR DESCRIPTION
Fixed bug in error messages which shows "1 persons listed" or "1 modules listed"